### PR TITLE
Fix instructions for method 3 in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,11 @@ Beyond this setup, the editing/testing process should be the same as outlined in
 
 ## Method 3: Commandline Testing (Simplest)
 
+In src/test.cpp, replace the line at the top that reads `#include <catch2/catch_test_macros.hpp>` with this line:
+```cpp
+#include "../catch/catch_amalgamated.hpp"
+```
+
 Run this command once from your project directory:
 ```sh
 g++ -std=c++14 -Werror -Wuninitialized -g -c catch/catch_amalgamated.cpp -o build/catch_amalgamated.o
@@ -110,8 +115,8 @@ g++ -std=c++14 -Werror -Wuninitialized -g -c catch/catch_amalgamated.cpp -o buil
 Then run these commands in order if you make any subsequent changes:
 
 ```sh
-g++ -std=c++14 -Werror -Wuninitialized -g build/catch_amalgamated.o src/test.cpp -o bin/test
-./bin/test
+g++ -std=c++14 -Werror -Wuninitialized -g build/catch_amalgamated.o src/test.cpp -o build/test
+./build/test
 ```
 
 This will show you which tests you pass.


### PR DESCRIPTION
Current instructions do not take into account that there is no `bin/` directory and the `#include` in `src/test.cpp` is for the CMake Catch2 version. This places the test executable in the `build/` directory and instructs the `#include` to be changed.