### PR TITLE
Adding run button

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "cmake.sourceDirectory": "/workspaces/Quiz-3-Catch-Template"
+    "cmake.sourceDirectory": "/workspaces/Quiz-3-Catch-Template",
+    "debug.internalConsoleOptions": "neverOpen"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,9 +5,9 @@
             "label": "C/C++: g++ build active file",
             "command": "/usr/bin/g++",
             "args": [
-                "-fdiagnostics-color=always",
                 "-g",
                 "${file}",
+                "${fileDirname}/../catch/catch_amalgamated.cpp",
                 "-o",
                 "${fileDirname}/${fileBasenameNoExtension}"
             ],


### PR DESCRIPTION
Modified tasks.json so that the "run" button in the top right of the codespace will compile and run the tests. 

Also modified the workspace settings to prevent the debug console from opening up and covering the terminal (where the Catch output is) when the run button is used.