### PR TITLE
Change method 3 on readme to have less ambiguous wording

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ Beyond this setup, the editing/testing process should be the same as outlined in
 
 ## Method 3: Commandline Testing (Simplest)
 
-In src/test.cpp, replace the line at the top that reads `#include <catch2/catch_test_macros.hpp>` with this line:
+In test/test.cpp, replace the line at the top that reads `#include <catch2/catch_test_macros.hpp>` with this line:
 ```cpp
 #include "catch/catch_amalgamated.hpp"
 ```
@@ -124,14 +124,14 @@ Run this command once from your project directory:
 ```sh
 g++ -std=c++14 -Werror -Wuninitialized -g -c test/catch/catch_amalgamated.cpp -o build/catch_amalgamated.o
 ```
-Then run these commands in order if you make any subsequent changes:
 
+Next, run these commands to build and view your tests:
 ```sh
 g++ -std=c++14 -Werror -Wuninitialized -g build/catch_amalgamated.o test/test.cpp -o build/test
 ./build/test
 ```
-
-This will show you which tests you pass.
+If you make any changes to your files, you can run the last two commands again.
+You do not need to run the first command again.
 
 # Assignment Description: Interquartile Range
 


### PR DESCRIPTION
Method 3 instructions changed to make clear that all 3 commands should be run on the first build, and then only the last 2 commands need to be run on subsequent builds. The previous instructions implied this, but this change makes it less ambiguous.